### PR TITLE
Chaining conditionals to avoid checking string value twice

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,11 +194,10 @@ def main():
 	else:
 		## This isn't working right now
 		while(True):
-			prompt = raw_input("Which build would you like [public|test]?\n>").lower()
-			if prompt.strip() == 'public':
-				build = 'public'
-			elif prompt.strip() == 'test':
-				build = 'test'
+			prompt = raw_input("Which build would you like [public|test]?\n>").lower().strip()
+			if prompt == 'public' or prompt == 'test':
+				build = prompt
+				break
 		sel_build = new_build_check(build)
 		print "\nLatest Build: {}".format(latest_build())
 		print "Selected Build: {}".format(sel_build)

--- a/main.py
+++ b/main.py
@@ -195,7 +195,7 @@ def main():
 		## This isn't working right now
 		while(True):
 			prompt = raw_input("Which build would you like [public|test]?\n>").lower().strip()
-			if prompt == 'public' or prompt == 'test':
+			if prompt in ('public','test'):
 				build = prompt
 				break
 		sel_build = new_build_check(build)

--- a/main.py
+++ b/main.py
@@ -197,10 +197,8 @@ def main():
 			prompt = raw_input("Which build would you like [public|test]?\n>").lower()
 			if prompt.strip() == 'public':
 				build = 'public'
-				break
-			if prompt.strip() == 'test':
+			elif prompt.strip() == 'test':
 				build = 'test'
-				break
 		sel_build = new_build_check(build)
 		print "\nLatest Build: {}".format(latest_build())
 		print "Selected Build: {}".format(sel_build)


### PR DESCRIPTION
And removed breaks. Same logic and processes the string only once if `prompt.strip()=='public'`, since there's just no need to check the same variable to see if it equals some value if you've already determined it's something else. 
